### PR TITLE
Fix issue with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language:
   - node_js
 
 node_js:
-  - "stable"
+  - "10" # This is the LTS version of Node at time of writing: https://docs.npmjs.com/try-the-latest-stable-version-of-node
 
 cache:
   npm: true # this cashes ~/.npm folder on Travis


### PR DESCRIPTION
It emerged today that the Travis CI build has broken since the last
merge to develop (at which point the build was working OK). It appears
that this is a result of the .travis.yaml file using "latest" for
the version of node_js.

Having done some research it seems the way to fix this is using the
latest LTS version of Node. At the time of writing this is 10.15.3.

See: https://docs.npmjs.com/try-the-latest-stable-version-of-node

I've therefore reverted to 10.x