### PR TITLE
Remove Cypress from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
 script:
   - npm test
   - npm run build
-  - $(npm bin)/cypress run --record --key ecf76371-5b01-40ad-a4bf-3179175cefc8
 
 notifications:
   slack:


### PR DESCRIPTION
We're getting failed builds because we're exceeding the monthly quota
for our 'free' Cypress account. This commit removes Cypress from the
.travis.yml but we will still be able to run it locally.

Really grateful if someone could merge this for me.