### PR TITLE
Update README to reflect CDN / Introduce versioning variables for targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,26 @@
 
 Jump to: 
 
-* [development machine configuration](#development-machine-configuration)
-* [steps to create a new component](#steps-to-create-a-new-component)
-* [testing](#testing)
+* [Getting started: development machine configuration](#development-machine-configuration)
+* [Steps to create a new component](#steps-to-create-a-new-component)
+* [Testing](#testing)
 
-## Background
+## Automatic deployment to CDN
+
+These components are available on our CDN, for example, at: 
+
+* https://cdn.nationalarchives.gov.uk/react-components/dist/discovery-1.0.0.js
+* https://cdn.nationalarchives.gov.uk/react-components/dist/website-1.0.0.js
+
+Note these **important things**: 
+
+- it is the `master` branch that is being watched for deployment to the CDN
+- the deployed script name will reflect that which is in `webpack.config.js`
+- it can take up to 24 hours for a _change_ to be replicated to all edge locations on CloudFront, but new files will typically be available much  faster
+
+## Appendices
+
+### Background
 
 In September 2018, front end developers at The National Archives met to identify a mechanism to address two significant factors impacting developer morale: 
 
@@ -33,15 +48,15 @@ For more information about this see the:
 * relevant section of the [front-end development guide](https://github.com/nationalarchives/front-end-development-guide/blob/master/development-guide.md)
 * associated [pull request](https://github.com/nationalarchives/front-end-development-guide/pull/21)
 
-## This is progressive enhancement
+### This is progressive enhancement
 
 Since these are JavaScript components it is vitally important developers recognise this _builds upon but does not replace_ our progressive enhancement approach. **The basic functionality required to achieve user goals must always be provided by the HTML of target applications**.
 
-## An example
+### An example
 
 We'll use The National Archives' 'global search' as an example to demonstrate this because it is present across many digital services. Since it's original implementation (in around 2014) it has been further developed and we have found that, since each implementation resides within the target application, some of the work has not found its way to all those places where it is implemented. Here is how we'd address this using a shared component. 
 
-### The basic HTML
+#### The basic HTML
 
 Each target environment has HTML introduced that will allow the user to achieve their goal. In this example, that is two links: one to the Discovery homepage and one to our website search homepage. 
 
@@ -58,11 +73,11 @@ Each target environment has HTML introduced that will allow the user to achieve 
 
 Since the destinations for these provide the user with the full range of search functionality we can improve the user experience through progressive enhancement.
 
-### Component that can be used across environments
+#### Component that can be used across environments
 
 We then develop a JavaScript component that enables the search to be submitted from the source page. This is added to the `tna-components` library.
 
-### A runner for each environment
+#### A runner for each environment
 
 So as to ensure target applications include only those components they need, we configure an [entry point for each target environment](https://webpack.js.org/concepts/entry-points/#object-syntax) in Webpack. These entry points: 
 
@@ -71,7 +86,7 @@ So as to ensure target applications include only those components they need, we 
 
 In this way we are able to develop and maintain components centrally while allowing each target environments to have control the deployment of scripts to staging environments.
 
-## Development machine configuration
+### Development machine configuration
 
 **Download the repository.**
 
@@ -98,7 +113,7 @@ In this way we are able to develop and maintain components centrally while allow
 
   Your site is now running at `http://localhost:3000`
 
-### Testing
+#### Testing
 
 **Jest - Unit|Itegration|Snapshot(s) testing**
 * `npm test`
@@ -110,15 +125,13 @@ In this way we are able to develop and maintain components centrally while allow
 **Cypress E2E testing**
 * `./node_modules/.bin/cypress open`
 
-## Steps to create a new component
+### Steps to create a new component
 
-Here's [an example commit](https://github.com/nationalarchives/tna-components/commit/048d8d65a9785f2cab2a4fb20b83d803feb7a33e) introducing the code that's needed to create a new component. At a high-level, the steps are: 
+Here's [an example commit](https://github.com/nationalarchives/tna-components/commit/048d8d65a9785f2cab2a4fb20b83d803feb7a33e) introducing the code that's needed to create a new component. At a high-level, the steps are:  
 
-There are essentially two steps to adding a component: 
-
-1. Preparing the server to serve the HTML into which the component will be mounted.
+1. Preparing the local development server to serve the HTML into which the component will be mounted.
 2. Creating the component
-3. Bumping the version number in `webpack.config.js` (using SEMVER)
+3. Bumping the relevant version number(s) in `webpack.config.js` (using [Semantic Versioning](https://semver.org/))
 3. Preparing a runner that will mount the component when specific conditions are met. 
 
 Here are the individual steps:
@@ -131,6 +144,6 @@ Here are the individual steps:
 * Create a directory for the component within `/components/` and place your component, tests and styles within.
 * Create a runner for the component within `/src/runners`. Note: the runner's purpose is to determine _if_ and _where_ a component is to be mounted. 
 
-### Core technologies
+#### Core technologies
 
 This repository uses a number of technologies, including: [React](https://reactjs.org), [Jest](https://jestjs.io), [Babel](https://babeljs.io), [Webpack](https://webpack.js.org),[Travis CI](https://travis-ci.org/), [Express JS](https://expressjs.com/), and [Cypress.io](https://cypress.io)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,12 @@
 const path = require('path');
 
-const version = `1.0.0`;
+const discovery_version = `1.1.0`;
+const website_version = `1.0.0`;
 
 module.exports = {
   entry: {
-    [`discovery-${version}`]: './src/discovery.js',
-    [`website-${version}`]: './src/website.js'
+    [`discovery-${discovery_version}`]: './src/discovery.js',
+    [`website-${website_version}`]: './src/website.js'
   },
   mode: 'production',
   output: {


### PR DESCRIPTION
These updates are: 

- Introducing separate variables in the `webpack.config.js` for Discovery and website build targets
- A few changes to reflect the new automated deployments to the CDN
- Some 'tidying' (including moving quite a lot of content to an 'appendices' section)